### PR TITLE
Added python setup for Mac M

### DIFF
--- a/Python/requirements_mac_m.txt
+++ b/Python/requirements_mac_m.txt
@@ -1,0 +1,7 @@
+numpy
+keras==2.13.1
+tensorflow==2.13.0
+matplotlib
+pandas
+scipy
+tflite

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Training data should be placed in the `Data` folder. Each recording should provi
 
 ### Linux setup:
 
-> Python version 3.10 or newer is required
+> Python version 3.10 or 3.11 is required
 
 1. Install python environment: (Debian package manager in this example. Use yours)
     ```sh
@@ -53,6 +53,18 @@ Training data should be placed in the `Data` folder. Each recording should provi
     ```sh
         python3 main.py
     ```
+
+### Mac M setup
+
+> Python version 3.11 is required
+
+1. Same steps as Linux but replace the `requirements` file in step `3`.
+
+    ```sh
+        pip install --upgrade pip && pip install -r requirements_mac_m.txt
+    ```
+
+
 
 ## Getting started - ESP-32
 


### PR DESCRIPTION
- Input from Workshop attendee regarding Python/Tensorflow setup for Apple Mac with M chips. 
- Added specific requirements file and updated the readme. 
- Also updated the README regarding python Linux setup. Feedback from Workshop - Python 3.12 is not working for our setup so I've restricted to 3.10 and 11. 